### PR TITLE
HTTPSClient.Client could not connect https

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -84,7 +84,7 @@ extension Client {
         var request = request
         addHeaders(&request)
 
-        let connection = try self.connection ?? TCPConnection(host: host, port: port)
+        let connection = try self.connection ?? TCPSSLConnection(host: host, port: port, verifyBundle: verifyBundle, certificate: certificate, privateKey: privateKey , certificateChain: certificateChain)
         try connection.open()
 
         try serializer.serialize(request, to: connection)
@@ -229,7 +229,7 @@ extension Request {
         get {
             return headers["User-Agent"].first
         }
-        
+
         set(userAgent) {
             headers["User-Agent"] = userAgent.map({Header($0)}) ?? []
         }


### PR DESCRIPTION
# Problem:

could not connect https host
https://gist.github.com/tomohisa/e32206ca65adda28abc6fc6200ce9808
# Reason:

did not use TCPSSLConnection, it was using TCPConnection.
# Fix:

changed to use TCPSSLConnection and passed parameters
