### PR TITLE
Could not connect https continued

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -71,7 +71,6 @@ public final class Client: Responder {
 
 extension Client {
     private func addHeaders(_ request: inout Request) {
-        var request = request
         request.host = "\(host):\(port)"
         request.userAgent = "Zewo"
 


### PR DESCRIPTION
# Problem:

could not connect https host
https://gist.github.com/tomohisa/e32206ca65adda28abc6fc6200ce9808
# Reason:

did not use TCPSSLConnection, it was using TCPConnection.
# Fix:

changed to use TCPSSLConnection and passed parameters
Needed to delete var request = request because its inout.
