### PR TITLE
'upgrade' name conflict

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -92,8 +92,8 @@ extension Client {
             let data = try connection.receive(upTo: 1024)
             if let response = try parser.parse(data)  {
 
-                if let upgrade = request.upgrade {
-                    try upgrade(response, connection)
+                if let onUpgrade = request.onUpgrade {
+                    try onUpgrade(response, connection)
                 }
 
                 if !keepAlive {
@@ -211,16 +211,16 @@ extension Request {
         }
     }
 
-    typealias Upgrade = (Response, Stream) throws -> Void
+    typealias OnUpgrade = (Response, Stream) throws -> Void
 
     // Warning: The storage key has to be in sync with Zewo.HTTP's upgrade property.
-    var upgrade: Upgrade? {
+    var onUpgrade: OnUpgrade? {
         get {
-            return storage["request-connection-upgrade"] as? Upgrade
+            return storage["request-connection-upgrade"] as? OnUpgrade
         }
 
-        set(upgrade) {
-            storage["request-connection-upgrade"] = upgrade
+        set(onUpgrade) {
+            storage["request-connection-upgrade"] = onUpgrade
         }
     }
 


### PR DESCRIPTION
## Problem

This is set with PR below
https://github.com/Zewo/HTTP/pull/10

Message and Request both uses “upgrade”

https://github.com/Zewo/HTTP/blob/master/Sources/Message.swift#L82

https://github.com/Zewo/HTTP/blob/master/Sources/Request.swift#L28
## Reason

S4 Defines Request is following protocol but upgrade for two different
reason.

https://github.com/open-swift/S4/blob/master/Sources/Request.swift#L1

```
public struct Request: Message {
```
## Fix

request.upgrade changes to
request.onUpgrade since this is callback function
