### PR TITLE
'upgrade' name conflict 

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -92,8 +92,8 @@ extension Client {
             let data = try connection.receive(upTo: 1024)
             if let response = try parser.parse(data)  {
 
-                if let upgrade = request.upgrade {
-                    try upgrade(response, connection)
+                if let onUpgrade = request.onUpgrade {
+                    try onUpgrade(response, connection)
                 }
 
                 if !keepAlive {
@@ -211,16 +211,16 @@ extension Request {
         }
     }
 
-    typealias Upgrade = (Response, Stream) throws -> Void
+    typealias OnUpgrade = (Response, Stream) throws -> Void
 
     // Warning: The storage key has to be in sync with Zewo.HTTP's upgrade property.
-    var upgrade: Upgrade? {
+    var onUpgrade: OnUpgrade? {
         get {
-            return storage["request-connection-upgrade"] as? Upgrade
+            return storage["request-connection-upgrade"] as? OnUpgrade
         }
 
-        set(upgrade) {
-            storage["request-connection-upgrade"] = upgrade
+        set(onUpgrade) {
+            storage["request-connection-upgrade"] = onUpgrade
         }
     }
 

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -216,11 +216,11 @@ extension Request {
     // Warning: The storage key has to be in sync with Zewo.HTTP's upgrade property.
     var onUpgrade: OnUpgrade? {
         get {
-            return storage["request-connection-upgrade"] as? OnUpgrade
+            return storage["request-upgrade"] as? OnUpgrade
         }
 
         set(onUpgrade) {
-            storage["request-connection-upgrade"] = onUpgrade
+            storage["request-upgrade"] = onUpgrade
         }
     }
 

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -92,8 +92,8 @@ extension Client {
             let data = try connection.receive(upTo: 1024)
             if let response = try parser.parse(data)  {
 
-                if let onUpgrade = request.onUpgrade {
-                    try onUpgrade(response, connection)
+                if let didUpgrade = request.didUpgrade {
+                    try didUpgrade(response, connection)
                 }
 
                 if !keepAlive {
@@ -211,16 +211,16 @@ extension Request {
         }
     }
 
-    typealias OnUpgrade = (Response, Stream) throws -> Void
+    typealias DidUpgrade = (Response, Stream) throws -> Void
 
     // Warning: The storage key has to be in sync with Zewo.HTTP's upgrade property.
-    var onUpgrade: OnUpgrade? {
+    var didUpgrade: DidUpgrade? {
         get {
-            return storage["request-upgrade"] as? OnUpgrade
+            return storage["request-upgrade"] as? DidUpgrade
         }
 
-        set(onUpgrade) {
-            storage["request-upgrade"] = onUpgrade
+        set(didUpgrade) {
+            storage["request-upgrade"] = didUpgrade
         }
     }
 


### PR DESCRIPTION
## Problem

Message and Request both uses “upgrade”
## Reason

S4 Defines Request is following protocol but upgrade for two different
reason.

```
public struct Request: Message {
```
## Fix

request.upgrade changes to
request.didUpgrade since this is callback function

sending all related
Zewo/HTTP
VeniceX/HTTPClient
VeniceX/HTTPSClient
VeniceX/HTTPServer
VeniceX/HTTPSServer
PR

Also Stroage[""] Parameter should be consistent
for Request use storage["request-upgrade"]
for Response use  storage["response-connection-upgrade"]
cnosistencely
