### PR TITLE
Keep Alive fix, zero data hang fix, warning fix

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -144,7 +144,12 @@ extension Client {
     private func send(_ request: Request, middleware: [Middleware]) throws -> Response {
         var request = request
         addHeaders(to: &request)
-        return try middleware.chain(to: self).respond(to: request)
+        let response = try middleware.chain(to: self).respond(to: request)
+        if 400..<600 ~= response.status.statusCode {
+            //error response code, destroy the connection
+            self.connection = nil
+        }
+        return response
     }
 }
 

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -29,6 +29,7 @@
 public enum ClientError: ErrorProtocol {
     case httpsSchemeRequired
     case hostRequired
+    case brokenConnection
 }
 
 public final class Client: Responder {
@@ -106,6 +107,7 @@ extension Client {
             )
 
             try connection.open(timingOut: now() + connectionTimeout)
+            self.connection = connection
         }
 
         let requestDeadline = now() + requestTimeout
@@ -126,6 +128,9 @@ extension Client {
                 }
 
                 return response
+            } else if data.count == 0 {
+                //no data received, connection got broken
+                throw ClientError.brokenConnection
             }
         }
     }

--- a/Source/ClientConfiguration.swift
+++ b/Source/ClientConfiguration.swift
@@ -47,7 +47,7 @@ public struct ClientConfiguration {
         self.bufferSize = bufferSize
     }
 
-    public init(_ build: ClientConfigurationBuilder -> Void) {
+    public init(_ build: (ClientConfigurationBuilder) -> Void) {
         let configuration = ClientConfigurationBuilder()
         build(configuration)
 


### PR DESCRIPTION
Multiple things:
- fixes Keep Alive by actually storing the created connection, so that it can be reused in the next request
- wipes the connection when an error is received, as many times the server drops it anyway, this should prevent some of the brokenConnection errors
- (needs a discussion) added a check for empty data, I was getting a failure, receiving no data, but the error was getting caught deeper, decrypted zero data into zero data, returned it as valid data, parsing failed (bc it's empty data), but would keep trying instead of bailing out. I added another type of error: brokenConnection, but a better name like `noData` would probably be more appropriate. Comments please.
- fixed warning in tests (missing parens in a closure signature)
